### PR TITLE
Remove spurious prereqs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,6 @@ WriteMakefile
      VERSION_FROM	=> './lib/Test.pm',
      ABSTRACT_FROM	=> './lib/Test.pm',
      PREREQ_PM	  	=> {
-       'Test::Harness' => 1.1601,
        'File::Spec'    => 0,
      },
      INSTALLDIRS        => 'perl',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,6 @@ WriteMakefile
      VERSION_FROM	=> './lib/Test.pm',
      ABSTRACT_FROM	=> './lib/Test.pm',
      PREREQ_PM	  	=> {
-       'File::Spec'    => 0,
      },
      INSTALLDIRS        => 'perl',
     );


### PR DESCRIPTION
This removes the Test::Harness and File::Spec prereqs, since they don't really make sense and result in a circular dependency.

This is a blead upstream module, but the issue here is in the packaging, which is apparently maintained outside core.